### PR TITLE
feat. support setLocalVoiceChanger

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -35,5 +35,5 @@ android {
 }
 
 dependencies {
-    implementation 'io.agora.rtc:full-sdk:2.8.0'
+    implementation 'io.agora.rtc:full-sdk:2.8.1'
 }

--- a/android/src/main/java/io/agora/agorartcengine/AgoraRtcEnginePlugin.java
+++ b/android/src/main/java/io/agora/agorartcengine/AgoraRtcEnginePlugin.java
@@ -260,6 +260,12 @@ public class AgoraRtcEnginePlugin implements MethodCallHandler {
                 result.success(null);
             }
             break;
+            case "setLocalVoiceChanger": {
+                int changer = call.argument("changer");
+                mRtcEngine.setLocalVoiceChanger(changer);
+                result.success(null);
+            }
+            break;
             case "setRemoteRenderMode": {
                 int uid = call.argument("uid");
                 int mode = call.argument("mode");

--- a/ios/Classes/AgoraRtcEnginePlugin.m
+++ b/ios/Classes/AgoraRtcEnginePlugin.m
@@ -227,6 +227,10 @@
     NSInteger mode = [self intFromArguments:arguments key:@"mode"];
     [self.agoraRtcEngine setLocalRenderMode:mode];
     result(nil);
+  } else if ([@"setLocalVoiceChanger" isEqualToString:method]) {
+    NSInteger changer = [self intFromArguments:arguments key:@"changer"];
+    [self.agoraRtcEngine setLocalVoiceChanger:changer];
+    result(nil);
   } else if ([@"setRemoteRenderMode" isEqualToString:method]) {
     NSInteger uid = [self intFromArguments:arguments key:@"uid"];
     NSInteger mode = [self intFromArguments:arguments key:@"mode"];

--- a/lib/agora_rtc_engine.dart
+++ b/lib/agora_rtc_engine.dart
@@ -236,7 +236,7 @@ class AgoraRtcEngine {
   /// Before calling this method to set a new channel profile, [destroy] the current RtcEngine and [create] a new RtcEngine first.
   /// Call this method before [joinChannel], you cannot configure the channel profile when the channel is in use.
   static Future<void> setChannelProfile(ChannelProfile profile) async {
-     await _channel.invokeMethod('setChannelProfile', {'profile': profile.index});
+    await _channel.invokeMethod('setChannelProfile', {'profile': profile.index});
   }
 
   /// Sets the role of a user (Live Broadcast only).
@@ -479,6 +479,12 @@ class AgoraRtcEngine {
   static Future<void> setLocalRenderMode(VideoRenderMode renderMode) async {
     await _channel.invokeMethod(
         'setLocalRenderMode', {'mode': _intFromVideoRenderMode(renderMode)});
+  }
+
+  /// Sets the local voice changer option.
+  static Future<void> setLocalVoiceChanger(VoiceChanger changer) async {
+    await _channel.invokeMethod(
+        'setLocalVoiceChanger', {'changer': _intLocalVoiceChangere(changer)});
   }
 
   /// Sets the remote video display mode.
@@ -1004,6 +1010,31 @@ class AgoraRtcEngine {
         return 1;
     }
   }
+
+  static int _intLocalVoiceChangere(VoiceChanger changer) {
+    switch (changer) {
+      case VoiceChanger.VOICE_CHANGER_OLDMAN:
+        return 1;
+        break;
+      case VoiceChanger.VOICE_CHANGER_BABYBOY:
+        return 2;
+        break;
+      case VoiceChanger.VOICE_CHANGER_BABYGILR:
+        return 3;
+        break;
+      case VoiceChanger.VOICE_CHANGER_ZHUBAJIE:
+        return 4;
+        break;
+      case VoiceChanger.VOICE_CHANGER_ETHEREAL:
+        return 5;
+        break;
+      case VoiceChanger.VOICE_CHANGER_HULK:
+        return 6;
+        break;
+      default:
+        return 0;
+    }
+  }
 }
 
 class AudioVolumeInfo {
@@ -1202,6 +1233,29 @@ enum VideoRenderMode {
 
   /// Uniformly scale the video until one of its dimension fits the boundary (zoomed to fit). Areas that are not filled due to the disparity in the aspect ratio are filled with black.
   Fit,
+}
+
+enum VoiceChanger {
+  /// The original voice (no local voice change).
+  VOICE_CHANGER_OFF,
+
+  /// An old man's voice.
+  VOICE_CHANGER_OLDMAN,
+
+  /// A little boy's voice.
+  VOICE_CHANGER_BABYBOY,
+
+  ///A little girl's voice.
+  VOICE_CHANGER_BABYGILR,
+
+  /// Zhu Bajie's voice (Zhu Bajie is a character from Journey to the West who has a voice like a growling bear).
+  VOICE_CHANGER_ZHUBAJIE,
+
+  /// Ethereal vocal effects.
+  VOICE_CHANGER_ETHEREAL,
+
+  /// Hulk's voice.
+  VOICE_CHANGER_HULK
 }
 
 enum UserPriority {


### PR DESCRIPTION
目的：主要是针对 #23 提到的问题进行修复，新增了对[语音变声效果](https://docs.agora.io/cn/Audio%20Broadcast/voice_effect_android_audio?platform=Android)的支持。

做法：根据SDK预设的6个选项，新增了枚举类型：
```dart
enum VoiceChanger {
  /// The original voice (no local voice change).
  VOICE_CHANGER_OFF,

  /// An old man's voice.
  VOICE_CHANGER_OLDMAN,

  /// A little boy's voice.
  VOICE_CHANGER_BABYBOY,

  ///A little girl's voice.
  VOICE_CHANGER_BABYGILR,

  /// Zhu Bajie's voice (Zhu Bajie is a character from Journey to the West who has a voice like a growling bear).
  VOICE_CHANGER_ZHUBAJIE,

  /// Ethereal vocal effects.
  VOICE_CHANGER_ETHEREAL,

  /// Hulk's voice.
  VOICE_CHANGER_HULK
}
```

并在**invokeMethod方法**转换为[整形参数](https://docs.agora.io/cn/Audio%20Broadcast/API%20Reference/java/classio_1_1agora_1_1rtc_1_1_rtc_engine.html#ade6883c7878b7a596d5b2563462597dd)。

特别说明：需要升级[io.agora.rtc:full-sdk](https://mvnrepository.com/artifact/io.agora.rtc/full-sdk?repo=jcenter)依赖到最新版，才有支持这个方法。