### PR TITLE
新增Pub仓库徽章，以便于迅速拉取最新版本

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # AgoraRtcEngine
 
+![pub package](https://img.shields.io/pub/v/agora_rtc_engine.svg)
+
 This Flutter plugin is a wapper for [Agora Video SDK](https://docs.agora.io/en).
 
 Agora.io provides building blocks for you to add real-time voice and video communications through a simple and powerful SDK. You can integrate the Agora SDK to enable real-time communications in your own application quickly.


### PR DESCRIPTION
参考[Flutter Plugins](https://github.com/flutter/plugins)，都添加了动态更新的徽章图标，以帮助开发迅速拉取最新Package，而不需要到[Dart Pub](https://pub.dev/packages/agora_rtc_engine)去寻找。