### PR TITLE
upgrade compileSdkVersion and fix #46, #52, #53

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,7 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
 
     defaultConfig {
         minSdkVersion 16

--- a/example/.gitignore
+++ b/example/.gitignore
@@ -28,6 +28,10 @@
 .pub/
 build/
 
+# Flutter v1.12 will create these files
+.flutter-plugins-dependencies
+**/flutter_export_environment.sh
+
 # Android related
 **/android/**/gradle-wrapper.jar
 **/android/.gradle

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
 
     lintOptions {
         disable 'InvalidPackage'


### PR DESCRIPTION
升级到[Android X](https://developer.android.com/jetpack/androidx)后，**compileSdkVersion**的最低为28，否则无法构建出apk。