### PR TITLE
fix Map casting exception in 'RtcEngine.getUserInfoByUid'

### DIFF
--- a/lib/src/rtc_engine.dart
+++ b/lib/src/rtc_engine.dart
@@ -196,7 +196,7 @@ class RtcEngine with RtcEngineInterface {
   @override
   Future<UserInfo> getUserInfoByUid(int uid) {
     return _invokeMethod('getUserInfoByUid', {'uid': uid}).then((value) {
-      return UserInfo.fromJson(value);
+      return UserInfo.fromJson((value as Map).cast());
     });
   }
 


### PR DESCRIPTION
Currently, when trying to call `RtcEngine#getUserInfoByUid` I'm getting following exception:
```
flutter: remote user mute state changed: 10003: muted: true
[VERBOSE-2:ui_dart_state.cc(177)] Unhandled Exception: type '_InternalLinkedHashMap<dynamic, dynamic>' is not a subtype of type 'Map<String, dynamic>'
#0      RtcEngine.getUserInfoByUid.<anonymous closure> (package:agora_rtc_engine/src/rtc_engine.dart:199:32)
#1      _rootRunUnary (dart:async/zone.dart:1198:47)
#2      _CustomZone.runUnary (dart:async/zone.dart:1100:19)
#3      _FutureListener.handleValue (dart:async/future_impl.dart:143:18)
#4      Future._propagateToListeners.handleValueCallback (dart:async/future_impl.dart:696:45)
#5      Future._propagateToListeners (dart:async/future_impl.dart:725:32)
#6      Future._completeWithValue (dart:async/future_impl.dart:529:5)
#7      _AsyncAwaitCompleter.complete (dart:async-patch/async_patch.dart:40:15)
#8      _completeOnAsyncReturn (dart:async-patch/async_patch.dart:311:13)
#9      MethodChannel._invokeMethod (package:flutter/src/services/platform_channel.dart)
<asynchronous suspension>
```

This pull request fixes the cast problem indicated above